### PR TITLE
Refactor: Remove creatorId and BROWSER_PLAYER_ID

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -130,9 +130,22 @@ function runValidationTests() {
         const defaultSettings = { dictionaryType: 'permissive', dictionaryUrl: null };
         const freeApiSettings = { dictionaryType: 'freeapi', dictionaryUrl: null };
         const customApiSettings = { dictionaryType: 'custom', dictionaryUrl: 'https://example.com/dict/' };
+        let originalLocalPlayerId;
+
+        // Helper to mock localPlayerId for these specific tests
+        const withMockLocalPlayerId = (id, fn) => {
+            originalLocalPlayerId = window.localPlayerId; // Assuming localPlayerId is global
+            window.localPlayerId = id;
+            try {
+                fn();
+            } finally {
+                window.localPlayerId = originalLocalPlayerId;
+            }
+        };
 
         TestSuite.it("should generate correct URL for a pass action", () => {
-            const url = generateTurnURL("game123", 5, null, null, null, null, ""); // Settings not relevant for non-initial pass
+            // generateTurnURL(gameId, turnNumber, turnData, seed = null, settings = null, exchangeData = null)
+            const url = generateTurnURL("game123", 5, null, null, null, ""); // seed, settings, exchangeData
             TestSuite.assertTrue(url.includes("gid=game123"), "URL should contain gameId");
             TestSuite.assertTrue(url.includes("tn=5"), "URL should contain turnNumber");
             TestSuite.assertTrue(url.includes("ex="), "URL should contain ex parameter for pass");
@@ -140,7 +153,7 @@ function runValidationTests() {
         });
 
         TestSuite.it("should generate correct URL for an exchange action with indices", () => {
-            const url = generateTurnURL("game456", 3, null, null, null, null, "0,2,5");
+            const url = generateTurnURL("game456", 3, null, null, null, "0,2,5"); // seed, settings, exchangeData
             TestSuite.assertTrue(url.includes("gid=game456"));
             TestSuite.assertTrue(url.includes("tn=3"));
             TestSuite.assertTrue(url.includes("ex=0,2,5"), "URL should contain ex parameter with indices");
@@ -148,17 +161,19 @@ function runValidationTests() {
 
         TestSuite.it("should generate URL for word play without ex parameter if exchangeData is null", () => {
             const wordData = { word: "HELLO", start_row: 7, start_col: 7, direction: 'horizontal', blanks_info: [] };
-            const url = generateTurnURL("game789", 2, wordData, null, null, defaultSettings, null); // Non-initial turn
+            // generateTurnURL(gameId, turnNumber, turnData, seed = null, settings = null, exchangeData = null)
+            const url = generateTurnURL("game789", 2, wordData, null, defaultSettings, null); // seed, settings, exchangeData (null for word play)
             TestSuite.assertTrue(url.includes("gid=game789"));
             TestSuite.assertTrue(url.includes("tn=2"));
             TestSuite.assertTrue(url.includes("w=HELLO"));
             TestSuite.assertFalse(url.includes("ex="), "URL for word play should not contain ex parameter");
+            // Settings (dt) should not be in non-initial URL
             TestSuite.assertFalse(url.includes("dt="), "Non-initial URL should not contain dt");
         });
 
         TestSuite.it("should prioritize ex parameter over wordData if both provided", () => {
             const wordData = { word: "HELLO", start_row: 7, start_col: 7, direction: 'horizontal', blanks_info: [] };
-            const url = generateTurnURL("gameXYZ", 4, wordData, null, null, defaultSettings, "1,3"); // Non-initial
+            const url = generateTurnURL("gameXYZ", 4, wordData, null, defaultSettings, "1,3"); // seed, settings, exchangeData
             TestSuite.assertTrue(url.includes("gid=gameXYZ"));
             TestSuite.assertTrue(url.includes("tn=4"));
             TestSuite.assertTrue(url.includes("ex=1,3"), "URL should contain ex parameter for exchange");
@@ -166,62 +181,81 @@ function runValidationTests() {
             TestSuite.assertFalse(url.includes("dt="), "Non-initial URL with ex should not contain dt");
         });
 
-        TestSuite.it("should include dictionary type for initial URL (turn 1, creator) if not permissive", () => {
-            const wordData = { word: "FIRST", start_row: 7, start_col: 7, direction: 'h', blanks_info:[]};
-            const url = generateTurnURL("gameInit", 1, wordData, 12345, "creator1", freeApiSettings, null);
-            TestSuite.assertTrue(url.includes("dt=freeapi"), "Initial URL should include dt=freeapi");
-            TestSuite.assertFalse(url.includes("du="), "Initial URL for freeapi should not include du");
+        TestSuite.it("should include dictionary type for initial URL (turn 1, localPlayerId='player1') if not permissive", () => {
+            withMockLocalPlayerId('player1', () => {
+                const wordData = { word: "FIRST", start_row: 7, start_col: 7, direction: 'h', blanks_info:[]};
+                // generateTurnURL(gameId, turnNumber, turnData, seed, settings, exchangeData)
+                const url = generateTurnURL("gameInit", 1, wordData, 12345, freeApiSettings, null);
+                TestSuite.assertTrue(url.includes("dt=freeapi"), "Initial URL for P1 should include dt=freeapi");
+                TestSuite.assertFalse(url.includes("du="), "Initial URL for freeapi should not include du");
+            });
         });
 
-        TestSuite.it("should include custom dictionary URL for initial URL if type is custom", () => {
-            const wordData = { word: "SETUP", start_row: 7, start_col: 7, direction: 'h', blanks_info:[]};
-            const url = generateTurnURL("gameCustom", 1, wordData, 54321, "creator2", customApiSettings, null);
-            TestSuite.assertTrue(url.includes("dt=custom"), "Initial URL should include dt=custom");
-            TestSuite.assertTrue(url.includes(`du=${encodeURIComponent(customApiSettings.dictionaryUrl)}`), "Initial URL should include du for custom type");
+        TestSuite.it("should include custom dictionary URL for initial URL (turn 1, localPlayerId='player1') if type is custom", () => {
+            withMockLocalPlayerId('player1', () => {
+                const wordData = { word: "SETUP", start_row: 7, start_col: 7, direction: 'h', blanks_info:[]};
+                const url = generateTurnURL("gameCustom", 1, wordData, 54321, customApiSettings, null);
+                TestSuite.assertTrue(url.includes("dt=custom"), "Initial URL for P1 should include dt=custom");
+                TestSuite.assertTrue(url.includes(`du=${encodeURIComponent(customApiSettings.dictionaryUrl)}`), "Initial URL for P1 should include du for custom type");
+            });
         });
 
-        TestSuite.it("should NOT include dictionary type for initial URL if permissive", () => {
-            const wordData = { word: "BEGIN", start_row: 7, start_col: 7, direction: 'h', blanks_info:[]};
-            const url = generateTurnURL("gamePerm", 1, wordData, 67890, "creator3", defaultSettings, null);
-            TestSuite.assertFalse(url.includes("dt="), "Initial URL for permissive should not include dt");
+        TestSuite.it("should NOT include dictionary type for initial URL (turn 1, localPlayerId='player1') if permissive", () => {
+            withMockLocalPlayerId('player1', () => {
+                const wordData = { word: "BEGIN", start_row: 7, start_col: 7, direction: 'h', blanks_info:[]};
+                const url = generateTurnURL("gamePerm", 1, wordData, 67890, defaultSettings, null);
+                TestSuite.assertFalse(url.includes("dt="), "Initial URL for P1 (permissive) should not include dt");
+            });
         });
+
+        TestSuite.it("should NOT include dictionary type for initial URL if localPlayerId is 'player2' (P2 making first move - unusual scenario)", () => {
+            withMockLocalPlayerId('player2', () => {
+                const wordData = { word: "FIRSTP2", start_row: 7, start_col: 7, direction: 'h', blanks_info:[]};
+                const url = generateTurnURL("gameInitP2", 1, wordData, 12345, freeApiSettings, null);
+                TestSuite.assertFalse(url.includes("dt="), "Initial URL generated by P2 should not include dt");
+            });
+        });
+
 
         TestSuite.it("should NOT include dictionary type for non-initial URLs (turn > 1)", () => {
+            // localPlayerId doesn't matter here as turn > 1
             const wordData = { word: "NEXT", start_row: 7, start_col: 8, direction: 'h', blanks_info:[]};
-            const url = generateTurnURL("gameNext", 2, wordData, null, null, freeApiSettings, null); // seed & creator null for non-initial
+            const url = generateTurnURL("gameNext", 2, wordData, null, freeApiSettings, null); // seed, settings, exchangeData
             TestSuite.assertFalse(url.includes("dt="), "Non-initial URL should not include dt even if settings provided");
         });
     });
 
     // Helper to setup a basic game state for testing pass/exchange handlers
-    function setupTestGame(initialSeed = 12345, gameSettings = {}, specificRack = null, specificBag = null) {
+    function setupTestGame(initialSeed = 12345, gameSettings = {}, p1Rack = null, p2Rack = null, bagContents = null, currentLocalPlayerId = "player1", currentPlayerIdx = 0, currentTurn = 1) {
         currentGame = new GameState("testGame", initialSeed, gameSettings);
-        localPlayerId = "player1"; // Assume P1 is running the test functions locally
+
+        // Set global localPlayerId for the test context
+        window.localPlayerId = currentLocalPlayerId;
+
         currentGame.players[0].name = "Player 1";
         currentGame.players[1].name = "Player 2";
-        currentGame.currentPlayerIndex = 0;
-        currentGame.turnNumber = 1;
+        currentGame.currentPlayerIndex = currentPlayerIdx;
+        currentGame.turnNumber = currentTurn;
 
-        currentGame.players[0].rack = specificRack || [
-            new Tile('R1',1, false, null, "tile_rack1"), new Tile('R2',1, false, null, "tile_rack2"),
-            new Tile('R3',1, false, null, "tile_rack3"), new Tile('R4',1, false, null, "tile_rack4"),
-            new Tile('R5',1, false, null, "tile_rack5"), new Tile('R6',1, false, null, "tile_rack6"),
-            new Tile('R7',1, false, null, "tile_rack7")
+        currentGame.players[0].rack = p1Rack || [
+            mockTile('R1',1,false,null,"r1"), mockTile('R2',1,false,null,"r2"), mockTile('R3',1,false,null,"r3"),
+            mockTile('R4',1,false,null,"r4"), mockTile('R5',1,false,null,"r5"), mockTile('R6',1,false,null,"r6"),
+            mockTile('R7',1,false,null,"r7")
         ];
-        currentGame.players[1].rack = [mockTile('P2A'), mockTile('P2B')]; // Minimal for P2
+        currentGame.players[1].rack = p2Rack || [mockTile('P2A'), mockTile('P2B')];
 
-        currentGame.bag = specificBag || [
-            new Tile('B1',10, false, null, "tile_bag1"), new Tile('B2',10, false, null, "tile_bag2"),
-            new Tile('B3',10, false, null, "tile_bag3"), new Tile('B4',10, false, null, "tile_bag4"),
-            new Tile('B5',10, false, null, "tile_bag5")
+        currentGame.bag = bagContents || [
+            mockTile('B1',10,false,null,"b1"), mockTile('B2',10,false,null,"b2"), mockTile('B3',10,false,null,"b3"),
+            mockTile('B4',10,false,null,"b4"), mockTile('B5',10,false,null,"b5")
         ];
 
-        // Ensure Tile constructor assigns unique ID if not provided for this test
-        // The Tile constructor in script.js already creates a unique this.id
-        // Forcing IDs here for predictability in tests.
-
-        // Mock UI elements that might be updated
-        document.body.innerHTML += '<input type="text" id="turn-url">'; // Ensure turn-url input exists
+        // Ensure turn-url input exists for tests that update it
+        if (!document.getElementById('turn-url')) {
+            const turnUrlInput = document.createElement('input');
+            turnUrlInput.type = 'text';
+            turnUrlInput.id = 'turn-url';
+            document.body.appendChild(turnUrlInput);
+        }
         return currentGame;
     }
 
@@ -230,25 +264,27 @@ function runValidationTests() {
     const _originalPrompt = window.prompt;
     let _mockAlertMessage = "";
     let _mockPromptResponse = "";
-    let mockNextRandom = 0.5; // Default mock random value
+    // let mockNextRandom = 0.5; // Default mock random value (PRNG mocking not used here)
+    let _originalWindowLocalPlayerId; // To backup global localPlayerId
 
     TestSuite.describe("Pass and Exchange Logic", () => {
         let game;
 
-        const mockUIAndRandom = () => {
+        const mockUI = () => {
             window.alert = (msg) => { _mockAlertMessage = msg; console.log("Mock Alert:", msg); };
             window.prompt = (msg) => { console.log("Mock Prompt:", msg); return _mockPromptResponse; };
-            // Mulberry32 is initialized in GameState. To control drawing, we'd need to mock the PRNG instance
-            // or ensure a fixed seed and predictable sequence. For these tests, fixed seed in setupTestGame is enough.
+            _originalWindowLocalPlayerId = window.localPlayerId; // Backup before test potentially changes it
         };
-        const unMockUIAndRandom = () => {
+        const unMockUI = () => {
             window.alert = _originalAlert;
             window.prompt = _originalPrompt;
+            window.localPlayerId = _originalWindowLocalPlayerId; // Restore
         };
 
         TestSuite.it("handlePassTurn: should advance turn, switch player, generate pass URL", () => {
-            mockUIAndRandom();
-            game = setupTestGame(123, {}); // seed, settings
+            mockUI();
+            // Setup: P1's turn (idx 0), local player is P1.
+            game = setupTestGame(123, {}, null, null, null, "player1", 0, 1);
             const initialTurn = game.turnNumber;
             const initialPlayerIndex = game.currentPlayerIndex;
             const p1RackBefore = [...game.players[0].rack];
@@ -265,26 +301,24 @@ function runValidationTests() {
             TestSuite.assertTrue(turnUrlInput.value.includes("ex="), "Turn URL should indicate a pass.");
             TestSuite.assertFalse(turnUrlInput.value.includes("ex=0"), "Turn URL for pass should be 'ex=' not 'ex=0'.");
             TestSuite.assertTrue(_mockAlertMessage.includes("Turn passed!"), "Alert message for pass is incorrect.");
-            unMockUIAndRandom();
+            unMockUI();
         });
 
         TestSuite.it("handleExchangeTiles: should exchange tiles, update rack/bag, advance turn, generate exchange URL", () => {
-            mockUIAndRandom();
-            // Setup with specific, identifiable tiles using the updated setupTestGame
-            // Provide explicit IDs for tiles to make assertions easier.
-            const rackTiles = [
-                new Tile('R1',1,false,null, "racktile1"), new Tile('R2',1,false,null, "racktile2"),
-                new Tile('R3',1,false,null,"racktile3")
+            mockUI();
+            const p1InitialRack = [
+                mockTile('R1',1,false,null, "racktile1"), mockTile('R2',1,false,null, "racktile2"),
+                mockTile('R3',1,false,null,"racktile3")
             ];
-            // Ensure bag has enough distinct tiles to draw, different from rack tiles
-            const bagTiles = [
-                new Tile('B1',10,false,null,"bagtile1"), new Tile('B2',10,false,null,"bagtile2"),
-                new Tile('B3',10,false,null,"bagtile3") // Extra tile in bag
+            const initialBag = [
+                mockTile('B1',10,false,null,"bagtile1"), mockTile('B2',10,false,null,"bagtile2"),
+                mockTile('B3',10,false,null,"bagtile3")
             ];
-            game = setupTestGame(123, [...rackTiles], [...bagTiles]); // Pass copies
+            // Setup: P1's turn (idx 0), local player is P1.
+            game = setupTestGame(123, {}, [...p1InitialRack], null, [...initialBag], "player1", 0, 1);
 
             const p1 = game.players[0];
-            const initialRackSize = p1.rack.length; // Should be 3
+            const initialRackSize = p1.rack.length; // Should be 3 from p1InitialRack
             const initialBagSize = game.bag.length;   // Should be 3
             const tilesToExchangeIndicesStr = "0,2"; // Exchange R1 (id: racktile1) and R3 (id: racktile3)
             _mockPromptResponse = tilesToExchangeIndicesStr;
@@ -337,46 +371,45 @@ function runValidationTests() {
             const turnUrlInput = document.getElementById('turn-url');
             TestSuite.assertTrue(turnUrlInput.value.includes(`ex=${tilesToExchangeIndicesStr}`), "Turn URL should indicate specific tiles exchanged.");
             TestSuite.assertTrue(_mockAlertMessage.includes(`Exchanged ${numberOfTilesExchanged} tile(s)`), "Alert message for exchange is incorrect.");
-            unMockUIAndRandom();
+            unMockUI();
         });
 
         TestSuite.it("handleExchangeTiles: should not exchange if bag has too few tiles", () => {
-            mockUIAndRandom();
-            // Use specific tile IDs for clarity
-            const rackTiles = [new Tile('R1',1,false,null,"r1"), new Tile('R2',1,false,null,"r2")];
-            const bagTiles = [new Tile('B1',10,false,null,"b1")]; // Only 1 tile in bag
-            // Pass empty gameSettings object {}
-            game = setupTestGame(123, {}, [...rackTiles], [...bagTiles]);
+            mockUI();
+            const p1InitialRack = [mockTile('R1',1,false,null,"r1"), mockTile('R2',1,false,null,"r2")];
+            const initialBag = [mockTile('B1',10,false,null,"b1")]; // Only 1 tile in bag
+            // Setup: P1's turn (idx 0), local player is P1.
+            game = setupTestGame(123, {}, p1InitialRack, null, initialBag, "player1", 0, 1);
 
             _mockPromptResponse = "0,1"; // Request to exchange 2 tiles
 
-            const p1RackBefore = game.players[0].rack.map(t => t.id); // Store IDs
+            const p1RackBeforeIds = game.players[0].rack.map(t => t.id);
             const initialTurn = game.turnNumber;
 
             handleExchangeTiles();
 
             const p1RackAfterIds = game.players[0].rack.map(t => t.id);
-            TestSuite.assertDeepEquals(p1RackBefore, p1RackAfterIds, "Player rack (by tile IDs) should be unchanged if bag is too small.");
+            TestSuite.assertDeepEquals(p1RackBeforeIds, p1RackAfterIds, "Player rack (by tile IDs) should be unchanged if bag is too small.");
             TestSuite.assertEquals(initialTurn, game.turnNumber, "Turn number should not change if exchange fails.");
             TestSuite.assertTrue(_mockAlertMessage.includes("Not enough tiles in the bag"), "Alert message for insufficient bag is incorrect.");
-            unMockUIAndRandom();
+            unMockUI();
         });
 
          TestSuite.it("handleExchangeTiles: should handle non-numeric/out-of-bounds indices gracefully", () => {
-            mockUIAndRandom();
-            const rackTiles = [
-                new Tile('R1',1,false,null,"r1"), new Tile('R2',1,false,null,"r2"),
-                new Tile('R3',1,false,null,"r3")
+            mockUI();
+            const p1InitialRack = [
+                mockTile('R1',1,false,null,"r1"), mockTile('R2',1,false,null,"r2"),
+                mockTile('R3',1,false,null,"r3")
             ];
-            const bagTiles = [new Tile('B1',10,false,null,"b1"), new Tile('B2',10,false,null,"b2")];
-            game = setupTestGame(123, {}, [...rackTiles], [...bagTiles]); // Pass empty gameSettings
+            const initialBag = [mockTile('B1',10,false,null,"b1"), mockTile('B2',10,false,null,"b2")];
+            // Setup: P1's turn (idx 0), local player is P1.
+            game = setupTestGame(123, {}, p1InitialRack, null, initialBag, "player1", 0, 1);
 
-            const p1RackOriginalIds = game.players[0].rack.map(t => t.id);
             _mockPromptResponse = "0,foo,10,1"; // Exchange R1 (idx 0) and R2 (idx 1). foo invalid, 10 out of bounds.
 
             handleExchangeTiles();
 
-            TestSuite.assertEquals(rackTiles.length, game.players[0].rack.length, "Rack size should be constant.");
+            TestSuite.assertEquals(p1InitialRack.length, game.players[0].rack.length, "Rack size should be constant.");
             // Tiles r1 and r2 should have been exchanged. r3 should remain.
             TestSuite.assertFalse(game.players[0].rack.some(t => t.id === "r1"), "Tile r1 should have been exchanged out.");
             TestSuite.assertFalse(game.players[0].rack.some(t => t.id === "r2"), "Tile r2 should have been exchanged out.");
@@ -387,7 +420,7 @@ function runValidationTests() {
             TestSuite.assertTrue(_mockAlertMessage.includes("Exchanged 2 tile(s)"), "Should report exchanging 2 valid tiles.");
             const turnUrlInput = document.getElementById('turn-url');
             TestSuite.assertTrue(turnUrlInput.value.includes("ex=0,foo,10,1"), "URL should contain original (unclean) indices as per current implementation.");
-            unMockUIAndRandom();
+            unMockUI();
         });
 
     });
@@ -405,110 +438,121 @@ function runValidationTests() {
     let mockStorage; // To be initialized in test setup
 
     TestSuite.describe("URL Processing for Pass/Exchange (via loadGameFromURLOrStorage)", () => {
-        let originalGameState; // To hold the state before URL processing
-
-        const P1_BROWSER_ID = "browserP1";
-        const P2_BROWSER_ID = "browserP2";
+        // let originalGameState; // To hold the state before URL processing (not strictly needed with full re-init)
+        let _originalWindowLocalPlayerId_URLTest; // Backup for window.localPlayerId
 
         // This setup runs before each 'it' block in this 'describe'
-        const beforeEachURLTest = (currentTurn, currentPlayerIdx, gameSettings = {}, localBrowserId = P1_BROWSER_ID) => {
+        const beforeEachURLTest = (currentTurnOnServer, currentPlayerIdxOnServer, gameSettings = {}, browserLocalPlayerId) => {
             mockStorage = MockLocalStorage();
-            currentGame = new GameState("urlTestGame", 67890, gameSettings); // Use provided settings
-            currentGame.turnNumber = currentTurn;
-            currentGame.currentPlayerIndex = currentPlayerIdx; // 0 for P1, 1 for P2
-            currentGame.creatorId = P1_BROWSER_ID; // P1 created the game
 
-            window.BROWSER_PLAYER_ID_backup = window.BROWSER_PLAYER_ID; // Backup global
-            window.BROWSER_PLAYER_ID = localBrowserId;
-            // Determine localPlayerId based on who is "viewing" this game instance
-            localPlayerId = (localBrowserId === currentGame.creatorId) ? "player1" : "player2";
+            // Set the window.localPlayerId to simulate who is opening the URL
+            _originalWindowLocalPlayerId_URLTest = window.localPlayerId;
+            window.localPlayerId = browserLocalPlayerId;
 
-            // Simulate player racks and bag for realism
-            currentGame.players[0].rack = [mockTile('A'), mockTile('B'), mockTile('C'), mockTile('D'), mockTile('E'), mockTile('F'), mockTile('G')];
-            currentGame.players[1].rack = [mockTile('H'), mockTile('I'), mockTile('J'), mockTile('K'), mockTile('L'), mockTile('M'), mockTile('N')];
-            currentGame.bag = [];
-            for(let i=0; i<20; i++) currentGame.bag.push(mockTile(`Z${i}`,10));
+            // If a game already exists in mockStorage (e.g. simulating P1 has played and P2 is loading)
+            // it should be set up by the test itself before calling loadGameFromURLOrStorage.
+            // This beforeEach is more for initializing the environment.
+            // The actual game state that loadGameFromURLOrStorage loads will come from mockStorage.
+            // So, the test case needs to save a relevant state to mockStorage first.
 
+            // For tests where P2 loads an initial URL from P1 (game not in P2's localStorage yet):
+            // currentGame will be null initially. loadGameFromURLOrStorage will create it.
 
-            saveGameStateToLocalStorage(currentGame, mockStorage); // Save initial state
-            originalGameState = JSON.parse(JSON.stringify(currentGame)); // Deep copy for comparison
+            // For tests where a player loads a subsequent URL (game already in their localStorage):
+            // The test should save a version of the game to mockStorage that reflects the player's prior state.
+            // Example: P1 (turn 1 done) -> P2 (loads P1's URL, makes turn 2) -> P1 (loads P2's URL)
+            // When testing P1 loading P2's URL, P1's localStorage would have game state after turn 1.
+
+            // Simplified: We'll create a base game state reflecting "server" state *before* the URL's action is applied,
+            // then save it from the perspective of the `browserLocalPlayerId`.
+            let gameToSave = new GameState("urlTestGame", 67890, gameSettings);
+            gameToSave.turnNumber = currentTurnOnServer;
+            gameToSave.currentPlayerIndex = currentPlayerIdxOnServer;
+            gameToSave.players[0].rack = [mockTile('A'), mockTile('B'), mockTile('C'), mockTile('D'), mockTile('E'), mockTile('F'), mockTile('G')];
+            gameToSave.players[1].rack = [mockTile('H'), mockTile('I'), mockTile('J'), mockTile('K'), mockTile('L'), mockTile('M'), mockTile('N')];
+            gameToSave.bag = []; for(let i=0; i<20; i++) gameToSave.bag.push(mockTile(`Z${i}`,10));
+
+            // Crucially, saveGameStateToLocalStorage uses the *global window.localPlayerId* to store savedLocalPlayerId
+            saveGameStateToLocalStorage(gameToSave, mockStorage);
         };
+
         const afterEachURLTest = () => {
-             window.BROWSER_PLAYER_ID = window.BROWSER_PLAYER_ID_backup; // Restore global
-             currentGame = null; // Clean up
+             window.localPlayerId = _originalWindowLocalPlayerId_URLTest; // Restore global
+             currentGame = null; // Clean up global currentGame
              mockStorage.clear();
         };
 
 
         TestSuite.it("P2 loads URL from P1 who passed turn (default permissive settings)", () => {
-            beforeEachURLTest(1, 0, {}, P2_BROWSER_ID); // P2 loading, P1's turn 1, default settings
-            const passUrlParams = "gid=urlTestGame&tn=2&ex=&seed=67890&creator=" + P1_BROWSER_ID;
+            // P1 (server current player idx 0) has just finished turn 1 by passing. URL is for turn 2.
+            // P2 (browserLocalPlayerId 'player2') is opening this URL.
+            // P2's localStorage has game state from end of turn 1 (P1 was current player).
+            beforeEachURLTest(1, 0, {}, 'player2');
+            const passUrlParams = "gid=urlTestGame&tn=2&ex=&seed=67890"; // No creator in URL
             loadGameFromURLOrStorage(passUrlParams, mockStorage);
 
             TestSuite.assertEquals(2, currentGame.turnNumber);
-            TestSuite.assertEquals(1, currentGame.currentPlayerIndex);
+            TestSuite.assertEquals(1, currentGame.currentPlayerIndex); // Should be P2's turn
             TestSuite.assertEquals("permissive", currentGame.settings.dictionaryType);
+            TestSuite.assertEquals("player2", window.localPlayerId, "Browser's localPlayerId should remain P2");
             afterEachURLTest();
         });
 
         TestSuite.it("P1 loads URL from P2 who exchanged tiles (default permissive settings)", () => {
-            beforeEachURLTest(2, 1, {}, P1_BROWSER_ID); // P1 loading, P2's turn 2
-            const p2InitialRackBeforeExchange = [...currentGame.players[1].rack]; // Copy P2's rack before exchange
-            const initialBagBeforeExchange = [...currentGame.bag];
+            // P2 (server current player idx 1) has just finished turn 2 by exchanging. URL is for turn 3.
+            // P1 (browserLocalPlayerId 'player1') is opening this URL.
+            // P1's localStorage has game state from end of turn 2 (P2 was current player).
+            beforeEachURLTest(2, 1, {}, 'player1');
+            const p2InitialRackBeforeExchangeInTest = [...currentGame.players[1].rack]; // P2's rack on "server"
+            const initialBagBeforeExchangeInTest = [...currentGame.bag];
 
             const exchangeUrlParams = "gid=urlTestGame&tn=3&ex=0,1"; // P2 exchanged 2 tiles
             loadGameFromURLOrStorage(exchangeUrlParams, mockStorage);
 
             TestSuite.assertEquals(3, currentGame.turnNumber);
-            TestSuite.assertEquals(0, currentGame.currentPlayerIndex);
+            TestSuite.assertEquals(0, currentGame.currentPlayerIndex); // Should be P1's turn
             TestSuite.assertEquals("permissive", currentGame.settings.dictionaryType);
+            TestSuite.assertEquals("player1", window.localPlayerId, "Browser's localPlayerId should remain P1");
 
-            // Verify P2's rack and bag were modified correctly due to exchange by P2
-            const p2 = currentGame.players[1];
-            TestSuite.assertEquals(7, p2.rack.length, "P2 rack size should be maintained.");
-            // Check that the two exchanged tiles are different from original first two
-            TestSuite.assertFalse(p2.rack[0].id === p2InitialRackBeforeExchange[0].id && p2.rack[1].id === p2InitialRackBeforeExchange[1].id, "P2's first two tiles should have changed.");
-            // Check that the two original tiles are now in the bag (approx check, PRNG makes exact hard without mocking it)
-            TestSuite.assertEquals(initialBagBeforeExchange.length, currentGame.bag.length, "Bag size should be maintained after exchange.");
+            const p2_gameState = currentGame.players[1];
+            TestSuite.assertEquals(7, p2_gameState.rack.length, "P2 rack size should be maintained.");
+            TestSuite.assertFalse(p2_gameState.rack[0].id === p2InitialRackBeforeExchangeInTest[0].id && p2_gameState.rack[1].id === p2InitialRackBeforeExchangeInTest[1].id, "P2's first two tiles should have changed.");
+            TestSuite.assertEquals(initialBagBeforeExchangeInTest.length, currentGame.bag.length, "Bag size should be maintained.");
             afterEachURLTest();
         });
 
         TestSuite.it("P2 loads initial game URL from P1 (first move pass) with 'freeapi' dictionary setting", () => {
-            // P2 has no local game. P1 (creator) makes first move (pass) and generates URL.
-            mockStorage = MockLocalStorage();
-            currentGame = null; // No game loaded yet for P2
-            window.BROWSER_PLAYER_ID_backup = window.BROWSER_PLAYER_ID;
-            window.BROWSER_PLAYER_ID = P2_BROWSER_ID; // P2 is this browser
+            mockStorage = MockLocalStorage(); // P2 has no game yet
+            _originalWindowLocalPlayerId_URLTest = window.localPlayerId;
+            window.localPlayerId = 'player2'; // P2 is this browser
 
-            const initialUrlWithP1Pass = `gid=newGameFreeApi&tn=1&seed=111&creator=${P1_BROWSER_ID}&dt=freeapi&ex=`;
+            const initialUrlWithP1Pass = `gid=newGameFreeApi&tn=1&seed=111&dt=freeapi&ex=`; // No creator
             loadGameFromURLOrStorage(initialUrlWithP1Pass, mockStorage);
 
             TestSuite.assertNotNull(currentGame, "Game should be initialized for P2.");
             TestSuite.assertEquals("newGameFreeApi", currentGame.gameId);
             TestSuite.assertEquals(1, currentGame.turnNumber, "Turn number should be 1 (P1's completed turn).");
             TestSuite.assertEquals(1, currentGame.currentPlayerIndex, "Current player should be P2 (index 1).");
-            TestSuite.assertEquals("player2", localPlayerId, "Local player ID for P2 should be 'player2'.");
+            TestSuite.assertEquals("player2", window.localPlayerId, "Local player ID for P2 should be 'player2'.");
             TestSuite.assertEquals("freeapi", currentGame.settings.dictionaryType, "Dictionary type should be 'freeapi'.");
             TestSuite.assertNull(currentGame.settings.dictionaryUrl, "Dictionary URL should be null for freeapi.");
             afterEachURLTest();
         });
 
          TestSuite.it("P2 loads initial game URL from P1 (no first move yet) with 'custom' dictionary setting", () => {
-            mockStorage = MockLocalStorage();
-            currentGame = null;
-            window.BROWSER_PLAYER_ID_backup = window.BROWSER_PLAYER_ID;
-            window.BROWSER_PLAYER_ID = P2_BROWSER_ID;
+            mockStorage = MockLocalStorage(); // P2 has no game yet
+            _originalWindowLocalPlayerId_URLTest = window.localPlayerId;
+            window.localPlayerId = 'player2';
 
             const customUrl = "https://my.dict.co/api?q=";
-            const initialUrlCustom = `gid=newGameCustom&seed=222&creator=${P1_BROWSER_ID}&dt=custom&du=${encodeURIComponent(customUrl)}`;
-            // Note: tn is missing, so it's pre-first-move state (turn 0, P1 to play)
+            const initialUrlCustom = `gid=newGameCustom&seed=222&dt=custom&du=${encodeURIComponent(customUrl)}`;
             loadGameFromURLOrStorage(initialUrlCustom, mockStorage);
 
             TestSuite.assertNotNull(currentGame);
             TestSuite.assertEquals("newGameCustom", currentGame.gameId);
             TestSuite.assertEquals(0, currentGame.turnNumber, "Turn should be 0 (P1 to make first move).");
             TestSuite.assertEquals(0, currentGame.currentPlayerIndex, "Player should be P1 (index 0).");
-            TestSuite.assertEquals("player2", localPlayerId);
+            TestSuite.assertEquals("player2", window.localPlayerId);
             TestSuite.assertEquals("custom", currentGame.settings.dictionaryType);
             TestSuite.assertEquals(customUrl, currentGame.settings.dictionaryUrl);
             afterEachURLTest();
@@ -516,22 +560,19 @@ function runValidationTests() {
 
 
         TestSuite.it("P2 loads initial game URL from P1 (first move word play) with 'permissive' (implicit)", () => {
-            mockStorage = MockLocalStorage();
-            currentGame = null;
-            window.BROWSER_PLAYER_ID_backup = window.BROWSER_PLAYER_ID;
-            window.BROWSER_PLAYER_ID = P2_BROWSER_ID;
+            mockStorage = MockLocalStorage(); // P2 has no game yet
+            _originalWindowLocalPlayerId_URLTest = window.localPlayerId;
+            window.localPlayerId = 'player2';
 
-            // No dt/du params means permissive
-            const initialUrlP1Word = `gid=newGameWord&tn=1&seed=333&creator=${P1_BROWSER_ID}&w=HELLO&wl=7.7&wd=h`;
+            const initialUrlP1Word = `gid=newGameWord&tn=1&seed=333&w=HELLO&wl=7.7&wd=h`; // No creator, no dt/du
             loadGameFromURLOrStorage(initialUrlP1Word, mockStorage);
 
             TestSuite.assertNotNull(currentGame);
             TestSuite.assertEquals("newGameWord", currentGame.gameId);
             TestSuite.assertEquals(1, currentGame.turnNumber); // P1's move applied
             TestSuite.assertEquals(1, currentGame.currentPlayerIndex); // P2's turn
-            TestSuite.assertEquals("player2", localPlayerId);
+            TestSuite.assertEquals("player2", window.localPlayerId);
             TestSuite.assertEquals("permissive", currentGame.settings.dictionaryType, "Default to permissive if no dt in URL.");
-            // Check that P1's score reflects HELLO (H4+E1+L1+L1+O1 = 8)
             TestSuite.assertEquals(8, currentGame.players[0].score, "P1 score for HELLO should be 8.");
             afterEachURLTest();
         });
@@ -959,220 +1000,224 @@ function runValidationTests() {
     });
 
     TestSuite.describe("Scoring via applyTurnDataFromURL", () => {
-        const P1_BROWSER_ID = "p1browser";
-        const P2_BROWSER_ID = "p2browser";
-        let game;
+        // No P1_BROWSER_ID or P2_BROWSER_ID needed
+        // let game; // Not needed as a suite-level variable, individual tests will use global `currentGame`
+        let _originalWindowLocalPlayerId_ScoringTest_v2; // Renamed to avoid conflict if copy-paste error
 
-        const setupGameForURLTest = (initialBoardTiles = [], turn = 1, currentPlayerIdx = 0, localBrowserId = P2_BROWSER_ID) => {
+        const setupGameForURLScoringTest_v2 = (initialBoardTiles = [], turnBeforeUrl, playerIdxBeforeUrl, browserViewingLPI) => {
             mockStorage = MockLocalStorage();
-            const gameId = "urlScoreTest";
+            const gameId = "urlScoreTest"; // Keep consistent for mockStorage
             const seed = 12345;
 
-            // Temporarily set global BROWSER_PLAYER_ID for correct localPlayerId determination in load/init
-            window.BROWSER_PLAYER_ID_backup = window.BROWSER_PLAYER_ID;
-            window.BROWSER_PLAYER_ID = localBrowserId;
+            _originalWindowLocalPlayerId_ScoringTest_v2 = window.localPlayerId;
+            window.localPlayerId = browserViewingLPI;
 
-            // Initialize a new game state or load if one was saved by a previous step.
-            // For these tests, we usually want a fresh state modified for the test case.
-            game = new GameState(gameId, seed, { tileValues: DEFAULT_TILE_VALUES });
-            game.creatorId = P1_BROWSER_ID; // P1 is always creator for these tests.
-            game.turnNumber = turn;
-            game.currentPlayerIndex = currentPlayerIdx; // This is player whose turn it *was* before URL data.
+            let baseGame = new GameState(gameId, seed, { tileValues: DEFAULT_TILE_VALUES });
+            baseGame.turnNumber = turnBeforeUrl;
+            baseGame.currentPlayerIndex = playerIdxBeforeUrl;
+            baseGame.players[0].score = 0;
+            baseGame.players[1].score = 0;
 
-            // Manually set scores to 0 for players
-            game.players[0].score = 0;
-            game.players[1].score = 0;
-
-            // Set up board with initial tiles
             initialBoardTiles.forEach(t => {
-                if (game.board.grid[t.r] && game.board.grid[t.r][t.c]) {
-                    game.board.grid[t.r][t.c].tile = t.tile;
-                    if (t.bonus) game.board.grid[t.r][t.c].bonus = t.bonus;
-                    if (t.bonusUsed) game.board.grid[t.r][t.c].bonusUsed = t.bonusUsed;
+                if (baseGame.board.grid[t.r] && baseGame.board.grid[t.r][t.c]) {
+                    baseGame.board.grid[t.r][t.c].tile = t.tile;
+                    if (t.bonus) baseGame.board.grid[t.r][t.c].bonus = t.bonus;
+                    if (t.bonusUsed) baseGame.board.grid[t.r][t.c].bonusUsed = t.bonusUsed;
                 }
             });
 
-            // Racks and bag might need adjustment for draw simulation if not covered by GameState constructor fully for tests
-            game.players[0].rack = [mockTile('S',1), mockTile('C',3), mockTile('R',1), mockTile('A',1), mockTile('B',3), mockTile('L',1), mockTile('E',1)]; // P1 Rack
-            game.players[1].rack = [mockTile('Q',10), mockTile('U',1), mockTile('I',1), mockTile('Z',10), mockTile('X',8), mockTile('J',8), mockTile('K',5)]; // P2 Rack
-            // Ensure bag has enough tiles for drawing after play
-            game.bag = []; for(let i=0; i<20; i++) game.bag.push(mockTile('Z', 10));
+            // Use distinct IDs for tiles if specific tile tracking is needed in assertions.
+            baseGame.players[0].rack = [mockTile('S',1,false,null,"s1"), mockTile('C',3,false,null,"c1"), mockTile('R',1,false,null,"r1"), mockTile('A',1,false,null,"a1"), mockTile('B',3,false,null,"b1"), mockTile('L',1,false,null,"l1"), mockTile('E',1,false,null,"e1")];
+            baseGame.players[1].rack = [mockTile('Q',10,false,null,"q2"), mockTile('U',1,false,null,"u2"), mockTile('I',1,false,null,"i2"), mockTile('Z',10,false,null,"z2"), mockTile('X',8,false,null,"x2"), mockTile('J',8,false,null,"j2"), mockTile('K',5,false,null,"k2")];
+            baseGame.bag = []; for(let i=0; i<30; i++) baseGame.bag.push(mockTile(`B${i}`, 1, false, null, `bag${i}`));
 
-
-            saveGameStateToLocalStorage(game, mockStorage); // Save this specific setup
-
-            // This global currentGame is what applyTurnDataFromURL will operate on after loadGameFromURLOrStorage retrieves it.
-            // So, the 'game' variable here is effectively the 'currentGame' that will be affected.
-            // No, loadGameFromURLOrStorage sets the global `currentGame`. The `game` var here is a local reference to that.
-            // localPlayerId is also set globally by loadGameFromURLOrStorage.
-            // We return `game` just to make assertions on it directly if needed, as it's the same object as global `currentGame`.
-            return game;
+            saveGameStateToLocalStorage(baseGame, mockStorage);
+            // Important: loadGameFromURLOrStorage in the test will load this into global `currentGame`.
+            // It will also potentially set global `localPlayerId` based on what was saved.
+            // So, the `browserViewingLPI` we set here is for `saveGameStateToLocalStorage`.
+            // The `loadGameFromURLOrStorage` in the test will then correctly simulate a browser opening a URL.
         };
 
-        const tearDownGameForURLTest = () => {
-            window.BROWSER_PLAYER_ID = window.BROWSER_PLAYER_ID_backup; // Restore
-            currentGame = null; // Clean up global
-            localPlayerId = null; // Clean up global
+        const tearDownGameForURLScoringTest_v2 = () => {
+            window.localPlayerId = _originalWindowLocalPlayerId_ScoringTest_v2;
+            currentGame = null;
             mockStorage.clear();
         };
 
         TestSuite.it("P2 loads URL from P1's simple word play, score calculated", () => {
-            // P1 plays HAT (H=4, A=1, T=1 -> 6 points). P1 is player index 0.
-            // Game state before this URL: P1 (idx 0) was current player, turn 1. Settings are default.
-            game = setupGameForURLTest([], 1, 0, P2_BROWSER_ID); // P2 is this browser
+            // P1 (playerIdxBeforeUrl=0) played HAT (6 pts). Turn was 1, now URL is for turn 2.
+            // P2 (browserViewingLPI='player2') is loading.
+            setupGameForURLScoringTest_v2([], 1, 0, 'player2');
 
-            const p1OriginalScore = game.players[0].score;
-            const p1OriginalRackSize = game.players[0].rack.length; // Should be 7 from setup
-            const initialBagSize = game.bag.length;
+            const p1OriginalScore = 0;
+            // After setup, loadGameFromURLOrStorage has NOT been called by setup.
+            // The test calls it. currentGame is not yet the fully processed one.
+            // We need to get initial bag size from the state *before* loadGameFromURLOrStorage.
+            // This means querying the state that was put into mockStorage.
+            // A bit complex. Let's assume initialBagSize before load is known or less critical for this exact assertion.
+            // Or, more simply, capture it from the `currentGame` that `loadGameStateFromLocalStorage` (called by `loadGameFromURLOrStorage`) prepares.
 
-            // gid, tn, w, wl, wd
-            const wordPlayURLParams = "gid=urlScoreTest&tn=2&w=HAT&wl=7.7&wd=horizontal";
+            const initialUrlParams = "gid=urlScoreTest&tn=2&w=HAT&wl=7.7&wd=horizontal";
 
-            // loadGameFromURLOrStorage will call applyTurnDataFromURL.
-            // applyTurnDataFromURL gets 'game' (which is 'currentGame') as its gameState.
-            // It will modify game.players[0].score (P1's score).
-            loadGameFromURLOrStorage(wordPlayURLParams, mockStorage);
+            // Manually load to get initial bag size from the perspective of the test runner *before* URL processing
+            // This simulates what loadGameFromURLOrStorage would do as its first step.
+            let gameLoadedForBagCheck = loadGameStateFromLocalStorage("urlScoreTest", mockStorage);
+            const initialBagSize = gameLoadedForBagCheck.bag.length;
+            const p1OriginalRackSize = gameLoadedForBagCheck.players[0].rack.length;
 
-            TestSuite.assertEquals(p1OriginalScore + 6, game.players[0].score, "P1's score should be 6.");
-            TestSuite.assertEquals(0, game.players[1].score, "P2's score should be 0.");
-            TestSuite.assertEquals(2, game.turnNumber, "Turn number should advance to 2.");
-            TestSuite.assertEquals(1, game.currentPlayerIndex, "Current player should be P2 (index 1).");
 
-            // Check P1's rack was refilled (3 tiles played, 3 drawn)
-            TestSuite.assertEquals(p1OriginalRackSize, game.players[0].rack.length, "P1's rack size should be restored.");
-            TestSuite.assertEquals(initialBagSize - 3, game.bag.length, "Bag should have 3 fewer tiles.");
+            loadGameFromURLOrStorage(initialUrlParams, mockStorage); // This updates global `currentGame`
 
-            tearDownGameForURLTest();
+            TestSuite.assertEquals(p1OriginalScore + 6, currentGame.players[0].score, "P1's score should be 6.");
+            TestSuite.assertEquals(0, currentGame.players[1].score, "P2's score should be 0.");
+            TestSuite.assertEquals(2, currentGame.turnNumber, "Turn number should advance to 2.");
+            TestSuite.assertEquals(1, currentGame.currentPlayerIndex, "Current player should be P2 (index 1).");
+            TestSuite.assertEquals(p1OriginalRackSize, currentGame.players[0].rack.length, "P1's rack size should be restored (7).");
+            TestSuite.assertEquals(initialBagSize - 3, currentGame.bag.length, "Bag should have 3 fewer tiles.");
+
+            tearDownGameForURLScoringTest_v2();
         });
 
         TestSuite.it("P1 loads URL from P2's word play with DL bonus", () => {
-            // P2 plays 'AXE' (A=1, X=8, E=1). X on DL. Score: A + X*2 + E = 1 + 8*2 + 1 = 1+16+1 = 18.
-            // P2 is player index 1. P2's move completes turn 2 (URL will be for tn=3).
-            // P1 (this browser) is loading.
-            // Board setup: DL at 7,8 (where X will be placed)
-            const initialBoard = [{r:7,c:8, bonus:BONUS_TYPES.DL}];
-            game = setupGameForURLTest(initialBoard, 2, 1, P1_BROWSER_ID);
+            // P2 (playerIdxBeforeUrl=1) played AXE (1+8*2+1=18). Turn was 2, URL for turn 3.
+            // P1 (browserViewingLPI='player1') is loading.
+            const initialBoard = [{r:7,c:8, bonus:BONUS_TYPES.DL}]; // X on DL
+            setupGameForURLScoringTest_v2(initialBoard, 2, 1, 'player1');
 
-            const p2OriginalScore = game.players[1].score; // Should be 0
-            const p2OriginalRackSize = game.players[1].rack.length;
-            const initialBagSize = game.bag.length;
+            const p2OriginalScore = 0;
+            let gameLoadedForBagCheck = loadGameStateFromLocalStorage("urlScoreTest", mockStorage);
+            const initialBagSize = gameLoadedForBagCheck.bag.length;
+            const p2OriginalRackSize = gameLoadedForBagCheck.players[1].rack.length;
 
             const wordPlayURLParams = "gid=urlScoreTest&tn=3&w=AXE&wl=7.7&wd=horizontal";
             loadGameFromURLOrStorage(wordPlayURLParams, mockStorage);
 
-            TestSuite.assertEquals(0, game.players[0].score, "P1's score should be 0.");
-            TestSuite.assertEquals(p2OriginalScore + 18, game.players[1].score, "P2's score should be 18.");
-            TestSuite.assertTrue(game.board.grid[7][8].bonusUsed, "DL bonus at 7,8 should be marked as used.");
-            TestSuite.assertEquals(3, game.turnNumber, "Turn number should advance to 3.");
-            TestSuite.assertEquals(0, game.currentPlayerIndex, "Current player should be P1 (index 0).");
-            TestSuite.assertEquals(p2OriginalRackSize, game.players[1].rack.length, "P2's rack size should be restored.");
-            TestSuite.assertEquals(initialBagSize - 3, game.bag.length, "Bag should have 3 fewer tiles after P2's play.");
+            TestSuite.assertEquals(0, currentGame.players[0].score, "P1's score should be 0.");
+            TestSuite.assertEquals(p2OriginalScore + 18, currentGame.players[1].score, "P2's score should be 18.");
+            TestSuite.assertTrue(currentGame.board.grid[7][8].bonusUsed, "DL bonus at 7,8 should be marked as used.");
+            TestSuite.assertEquals(3, currentGame.turnNumber, "Turn number should advance to 3.");
+            TestSuite.assertEquals(0, currentGame.currentPlayerIndex, "Current player should be P1 (index 0).");
 
+            TestSuite.assertEquals(p2OriginalRackSize, currentGame.players[1].rack.length, "P2's rack size should be restored.");
+            TestSuite.assertEquals(initialBagSize - 3, currentGame.bag.length, "Bag should have 3 fewer tiles after P2's play.");
 
-            tearDownGameForURLTest();
+            tearDownGameForURLScoringTest_v2();
         });
 
         TestSuite.it("P2 loads URL from P1's play including a blank tile", () => {
-            // P1 plays H(blank O)ME. H=4, blank O=0, M=3, E=1. Score: 4+0+3+1=8.
-            // Blank O is at index 1 of "HOME", placed at 7,8.
-            game = setupGameForURLTest([], 1, 0, P2_BROWSER_ID); // P2 is this browser
-            const p1OriginalScore = game.players[0].score;
-            const p1OriginalRackSize = game.players[0].rack.length;
-            const initialBagSize = game.bag.length;
+            // P1 (playerIdxBeforeUrl=0) plays H(blank O)ME (4+0+3+1=8). Turn was 1, URL for turn 2.
+            // P2 (browserViewingLPI='player2') is loading.
+            setupGameForURLScoringTest_v2([], 1, 0, 'player2');
 
-            // gid, tn, w, wl, wd, bt (blank tile: index_in_w:AssignedLetter)
+            const p1OriginalScore = 0;
+            let gameLoadedForBagCheck = loadGameStateFromLocalStorage("urlScoreTest", mockStorage);
+            const initialBagSize = gameLoadedForBagCheck.bag.length;
+            const p1OriginalRackSize = gameLoadedForBagCheck.players[0].rack.length;
+
+
             const wordPlayURLParams = "gid=urlScoreTest&tn=2&w=HOME&wl=7.7&wd=horizontal&bt=1:O";
             loadGameFromURLOrStorage(wordPlayURLParams, mockStorage);
 
-            TestSuite.assertEquals(p1OriginalScore + 8, game.players[0].score, "P1's score for HOME (blank O) should be 8.");
-            const tileAt78 = game.board.grid[7][8].tile; // Word HOME, H at 7,7, O(blank) at 7,8
+            TestSuite.assertEquals(p1OriginalScore + 8, currentGame.players[0].score, "P1's score for HOME (blank O) should be 8.");
+            const tileAt78 = currentGame.board.grid[7][8].tile;
             TestSuite.assertTrue(tileAt78.isBlank, "Tile at 7,8 should be blank.");
             TestSuite.assertEquals("O", tileAt78.assignedLetter, "Blank tile at 7,8 should be assigned 'O'.");
             TestSuite.assertEquals(0, tileAt78.value, "Blank tile value should be 0.");
-            TestSuite.assertEquals(p1OriginalRackSize, game.players[0].rack.length, "P1's rack size should be maintained after playing 4 tiles.");
-            TestSuite.assertEquals(initialBagSize - 4, game.bag.length, "Bag should have 4 fewer tiles for HOME.");
 
-            tearDownGameForURLTest();
+            TestSuite.assertEquals(p1OriginalRackSize, currentGame.players[0].rack.length, "P1's rack size should be maintained after playing 4 tiles.");
+            TestSuite.assertEquals(initialBagSize - 4, currentGame.bag.length, "Bag should have 4 fewer tiles for HOME.");
+
+            tearDownGameForURLScoringTest_v2();
         });
     });
 
     TestSuite.describe("LocalStorage Persistence of Dictionary Settings", () => {
         let mockStorage;
-        const P1_ID = "p1_localStorage_test";
+        let _originalWindowLocalPlayerId_LSTest;
 
         const setupLocalStorageTest = () => {
             mockStorage = MockLocalStorage();
-            // Mock BROWSER_PLAYER_ID for consistent creatorId
-            window.BROWSER_PLAYER_ID_backup = window.BROWSER_PLAYER_ID;
-            window.BROWSER_PLAYER_ID = P1_ID;
+            _originalWindowLocalPlayerId_LSTest = window.localPlayerId;
+            window.localPlayerId = 'player1'; // Set a default for saving, tests can override if needed
         };
         const teardownLocalStorageTest = () => {
-            window.BROWSER_PLAYER_ID = window.BROWSER_PLAYER_ID_backup;
+            window.localPlayerId = _originalWindowLocalPlayerId_LSTest;
             mockStorage.clear();
-            currentGame = null; // Ensure no leakage
+            currentGame = null;
         };
 
-        TestSuite.it("should save and load 'permissive' dictionary settings", () => {
+        TestSuite.it("should save and load 'permissive' dictionary settings and savedLocalPlayerId", () => {
             setupLocalStorageTest();
             const gameId = "lsPermissiveGame";
             const settings = { dictionaryType: 'permissive', dictionaryUrl: null };
-            let game = new GameState(gameId, 123, settings);
-            game.creatorId = P1_ID;
-            saveGameStateToLocalStorage(game, mockStorage);
+            let gameToSave = new GameState(gameId, 123, settings);
+            // window.localPlayerId is 'player1' from setupLocalStorageTest, so this will be saved
+            saveGameStateToLocalStorage(gameToSave, mockStorage);
 
+            // Before loading, change global localPlayerId to ensure loadGameStateFromLocalStorage sets it
+            window.localPlayerId = 'player_test_before_load';
             let loadedGame = loadGameStateFromLocalStorage(gameId, mockStorage);
+
             TestSuite.assertNotNull(loadedGame);
             TestSuite.assertEquals("permissive", loadedGame.settings.dictionaryType);
             TestSuite.assertNull(loadedGame.settings.dictionaryUrl);
+            TestSuite.assertEquals('player1', window.localPlayerId, "Global localPlayerId should be loaded from saved state.");
+
+            // Also check that the loaded raw object from storage had it
+            const rawStored = JSON.parse(mockStorage.getItem(LOCAL_STORAGE_KEY_PREFIX + gameId));
+            TestSuite.assertEquals('player1', rawStored.savedLocalPlayerId);
             teardownLocalStorageTest();
         });
 
         TestSuite.it("should save and load 'freeapi' dictionary settings", () => {
-            setupLocalStorageTest();
+            setupLocalStorageTest(); // window.localPlayerId will be 'player1'
             const gameId = "lsFreeApiGame";
             const settings = { dictionaryType: 'freeapi', dictionaryUrl: null };
             let game = new GameState(gameId, 456, settings);
-            game.creatorId = P1_ID;
             saveGameStateToLocalStorage(game, mockStorage);
 
             let loadedGame = loadGameStateFromLocalStorage(gameId, mockStorage);
             TestSuite.assertNotNull(loadedGame);
             TestSuite.assertEquals("freeapi", loadedGame.settings.dictionaryType);
             TestSuite.assertNull(loadedGame.settings.dictionaryUrl);
+            TestSuite.assertEquals('player1', window.localPlayerId); // Should be loaded
             teardownLocalStorageTest();
         });
 
         TestSuite.it("should save and load 'custom' dictionary settings with URL", () => {
-            setupLocalStorageTest();
+            setupLocalStorageTest(); // window.localPlayerId will be 'player1'
             const gameId = "lsCustomGame";
             const customUrl = "http://my.api.com/lookup=";
             const settings = { dictionaryType: 'custom', dictionaryUrl: customUrl };
             let game = new GameState(gameId, 789, settings);
-            game.creatorId = P1_ID;
             saveGameStateToLocalStorage(game, mockStorage);
 
             let loadedGame = loadGameStateFromLocalStorage(gameId, mockStorage);
             TestSuite.assertNotNull(loadedGame);
             TestSuite.assertEquals("custom", loadedGame.settings.dictionaryType);
             TestSuite.assertEquals(customUrl, loadedGame.settings.dictionaryUrl);
+            TestSuite.assertEquals('player1', window.localPlayerId); // Should be loaded
             teardownLocalStorageTest();
         });
 
-        TestSuite.it("loadGameStateFromLocalStorage should handle older game state without dictionary settings (defaulting)", () => {
-            setupLocalStorageTest();
+        TestSuite.it("loadGameStateFromLocalStorage should handle older game state (no savedLocalPlayerId, no dict settings)", () => {
+            setupLocalStorageTest(); // Sets global localPlayerId to 'player1' initially, but this will be changed by load
             const gameId = "lsOldGame";
-            // Simulate an old game state string that wouldn't have dictionaryType/Url in its settings field
             const oldGameSerializable = {
-                gameId: gameId, randomSeed: 101, settings: { boardSize: 15 }, // No dict settings
+                gameId: gameId, randomSeed: 101, settings: { boardSize: 15 },
                 turnNumber: 5, currentPlayerIndex: 0, players: [], bag: [], boardGrid: []
+                // No savedLocalPlayerId, no creatorId
             };
             mockStorage.setItem(LOCAL_STORAGE_KEY_PREFIX + gameId, JSON.stringify(oldGameSerializable));
 
+            // Change global localPlayerId before loading to see if it defaults correctly
+            window.localPlayerId = 'player_test_before_load_old';
             let loadedGame = loadGameStateFromLocalStorage(gameId, mockStorage);
+
             TestSuite.assertNotNull(loadedGame);
-            // GameState constructor defaults to 'permissive' if not provided in settings
-            TestSuite.assertEquals("permissive", loadedGame.settings.dictionaryType, "Should default to permissive for old state.");
-            TestSuite.assertNull(loadedGame.settings.dictionaryUrl, "Should default to null URL for old state.");
+            TestSuite.assertEquals("permissive", loadedGame.settings.dictionaryType, "Should default to permissive.");
+            TestSuite.assertNull(loadedGame.settings.dictionaryUrl, "Should default to null URL.");
+            TestSuite.assertEquals('player1', window.localPlayerId, "Global localPlayerId should default to 'player1' for old save lacking it.");
             teardownLocalStorageTest();
         });
     });


### PR DESCRIPTION
Removed `creatorId` from game state and `BROWSER_PLAYER_ID` along with the `getPlayerIdentifier` function.

Player identification (`localPlayerId`) is now handled by:
- Defaulting to 'player1' for new games.
- Defaulting to 'player2' when joining a game via URL for the first time.
- Saving and loading `localPlayerId` with the game state in localStorage for subsequent game loads.

URL generation for the first turn by Player 1 now correctly includes dictionary settings based on `localPlayerId` and `turnNumber` instead of `creatorId`. Updated all relevant tests to reflect these changes.