### PR TITLE
Fix: Ensure correct tile background on bonus squares

### DIFF
--- a/style.css
+++ b/style.css
@@ -98,8 +98,13 @@ body {
 .square.center { background-color: #6f9; }
 
 .tile-on-board {
-    background-color: #f5deb3;
+    /* background-color: #f5deb3; /* Moved to .square.tile-on-board for specificity */
     border: 1px solid #8b4513;
+}
+
+/* Ensure tile background overrides bonus square background */
+.square.tile-on-board {
+    background-color: #f5deb3; /* Wheat */
 }
 
 #info-container {


### PR DESCRIPTION
- Reverted prior JavaScript changes to drag opacity as they were unrelated to this issue.
- Modified CSS for `.tile-on-board` and added `.square.tile-on-board`.

This ensures that when a tile is placed on a bonus square, its own background color (`#f5deb3`) takes precedence over the bonus square's background color, due to correct CSS specificity and cascade order. Tiles on bonus squares will now have the same 'wheat' background as other placed tiles and rack tiles.