### PR TITLE
Refactor: Move game initialization to main.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@ T..d...d..T....
         </div> <!-- This closes info-container -->
     </div> <!-- This closes game-container -->
     </div> <!-- This closes game-wrapper -->
-    <script type="module" src="script.js"></script>
+    <script type="module" src="main.js"></script>
   <div id="post-move-modal" hidden>
     <p>Points Earned: <span id="modal-points-earned">0</span></p>
     <div><input type="checkbox" id="modal-copy-url-checkbox" checked> <label for="modal-copy-url-checkbox">Copy Turn URL</label></div>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,6 @@
+import { initializeGameAndEventListeners } from './script.js';
+
+// Initialize the game and event listeners when main.js is loaded by the browser
+initializeGameAndEventListeners();
+
+console.log("main.js executed: Game initialization called.");

--- a/script.js
+++ b/script.js
@@ -3268,5 +3268,4 @@ function initializeGameAndEventListeners() {
     });
 }
 
-
-initializeGameAndEventListeners();
+export { initializeGameAndEventListeners };


### PR DESCRIPTION
- I created main.js to import and call initializeGameAndEventListeners from script.js.
- I modified script.js to export initializeGameAndEventListeners and remove its direct invocation.
- I updated index.html to load main.js instead of script.js.

This change allows script.js to be imported into a test environment without executing DOM-dependent initialization code, preventing console errors related to missing elements.