### PR TITLE
Use a hash of the randomSeed string in HonorSystemBag instead of trea…

### DIFF
--- a/game/game_state_test.ts
+++ b/game/game_state_test.ts
@@ -36,7 +36,7 @@ describe("game state", () => {
     const player1GameState = new GameState("1", settings);
     await player1GameState.init();
     const initialRack = player1GameState.tilesHeld.map((t) => t.tile.letter);
-    expect(initialRack.join("")).toEqual("VTKTTNC");
+    expect(initialRack.join("")).toEqual("DCCLNYE");
 
     // Exchange the first, third, and last tiles.
     player1GameState.moveTile("rack", 0, "exchange", 0);
@@ -46,7 +46,7 @@ describe("game state", () => {
 
     // The rack should have new tiles.
     const newRack = player1GameState.tilesHeld.map((t) => t.tile.letter);
-    expect(newRack.join("")).toEqual("TTTNLEE");
+    expect(newRack.join("")).toEqual("CLNYSHS");
 
     // The turnUrlParams should contain the exchange.
     const params = player1GameState.turnUrlParams;
@@ -55,7 +55,7 @@ describe("game state", () => {
     // A new game state created from the params should have the same rack.
     const player2GameState = await GameState.fromParams(params);
     const player2Rack = await player2GameState.getTiles("1");
-    expect(player2Rack.map((t) => t.letter).join("")).toEqual("TTTNLEE");
+    expect(player2Rack.map((t) => t.letter).join("")).toEqual("CLNYSHS");
   });
 
   it("should apply the bingo bonus", async () => {
@@ -117,9 +117,9 @@ describe("game state", () => {
 
     await gameState.playWord();
 
-    expect(gameState.board.squares[7]?.[7]?.tile?.letter).toBe("B");
+    expect(gameState.board.squares[7]?.[7]?.tile?.letter).toBe("E");
     expect(gameState.board.squares[7]?.[8]?.tile?.letter).toBe("A");
-    expect(gameState.board.scores.get("1")).toEqual(4);
+    expect(gameState.board.scores.get("1")).toEqual(2);
   });
 
   it("should pass turn", async () => {
@@ -130,14 +130,14 @@ describe("game state", () => {
     const initialRack = player1GameState.tilesHeld
       .map((t) => t.tile.letter)
       .join("");
-    expect(initialRack).toBe("ESPRTSJ");
+    expect(initialRack).toBe("TRACWSR");
 
     // Pass (exchange no tiles)
     await player1GameState.passOrExchange();
     const rackAfterPass = player1GameState.tilesHeld
       .map((t) => t.tile.letter)
       .join("");
-    expect(rackAfterPass).toBe("ESPRTSJ");
+    expect(rackAfterPass).toBe("TRACWSR");
   });
 
   it("should exchange tiles 2", async () => {
@@ -146,7 +146,7 @@ describe("game state", () => {
     const gameState = new GameState("1", settings);
     await gameState.init();
     const initialRack = gameState.tilesHeld.map((t) => t.tile.letter).join("");
-    expect(initialRack).toBe("MLRUTSE");
+    expect(initialRack).toBe("IOAHFRG");
 
     // Move tiles to the exchange area.
     gameState.moveTile("rack", 0, "exchange", 0);
@@ -157,7 +157,7 @@ describe("game state", () => {
     const rackAfterPass = gameState.tilesHeld
       .map((t) => t.tile.letter)
       .join("");
-    expect(rackAfterPass).toBe("RUTSEIS");
+    expect(rackAfterPass).toBe("AHFRGIW");
   });
 
   describe("params", () => {
@@ -287,7 +287,7 @@ describe("game state", () => {
     await gameState.init();
 
     const tileToPlace = gameState.tilesHeld[0]!;
-    expect(tileToPlace.tile.letter).toBe("B");
+    expect(tileToPlace.tile.letter).toBe("E");
 
     // Move a tile to the board
     gameState.moveTile("rack", 0, 7, 7);

--- a/game/hash.ts
+++ b/game/hash.ts
@@ -1,0 +1,16 @@
+/**
+ * @file A simple, insecure string hash function.
+ */
+
+/**
+ * Computes the djb2 hash of a given string.
+ * @param str - The input string to hash.
+ * @returns The computed hash value.
+ */
+export function djb2Hash(str: string): number {
+    let hash = 5381; // Initial hash value
+    for (let i = 0; i < str.length; i++) {
+        hash = (hash * 33) ^ str.charCodeAt(i); // Hashing logic
+    }
+    return hash >>> 0; // Ensure a positive integer
+}

--- a/game/honor_system_bag.ts
+++ b/game/honor_system_bag.ts
@@ -18,6 +18,7 @@ limitations under the License.
 */
 
 import { Bag } from "./bag.js";
+import { djb2Hash } from "./hash.js";
 import { Mulberry32Prng } from "./mulberry32_prng.js";
 import { Tile } from "./tile.js";
 import { arraysEqual } from "./validation.js";
@@ -30,10 +31,7 @@ export class HonorSystemBag extends Bag {
     tiles: Iterable<Tile>,
     // Args for fromJSON.
     shuffle = true,
-    randomGenerator = new Mulberry32Prng(
-      // TODO(#95): Accept any string. (Hash it.)
-      BigInt(randomSeed),
-    ),
+    randomGenerator = new Mulberry32Prng(djb2Hash(randomSeed)),
   ) {
     super(tiles, randomGenerator, shuffle);
   }

--- a/game/honor_system_bag_test.ts
+++ b/game/honor_system_bag_test.ts
@@ -35,22 +35,22 @@ describe("honor system bag", () => {
       tiles: _tiles(1, 2, 3, 5, 8),
       randomSeed: "0x456789ab",
     });
-    expect(bag.draw(bag.size)).toEqual(_tiles(5, 8, 1, 3, 2));
+    expect(bag.draw(bag.size)).toEqual(_tiles(3, 5, 8, 1, 2));
   });
   it("should draw 1", () => {
     const bag = createHonorSystemBag({
       tiles: _tiles(1, 2, 3, 5, 8),
       randomSeed: "1",
     });
-    expect(bag.draw(1)).toEqual(_tiles(8));
-    expect(bag.draw(bag.size)).toEqual(_tiles(2, 3, 1, 5));
+    expect(bag.draw(1)).toEqual(_tiles(3));
+    expect(bag.draw(bag.size)).toEqual(_tiles(8, 2, 1, 5));
   });
   it("should draw all", () => {
     const bag = createHonorSystemBag({
       tiles: _tiles(1, 2, 3, 5, 8),
       randomSeed: "1",
     });
-    expect(bag.draw(5)).toEqual(_tiles(2, 3, 1, 5, 8));
+    expect(bag.draw(5)).toEqual(_tiles(8, 2, 1, 5, 3));
     expect(bag.draw(bag.size)).toEqual(_tiles());
   });
   it("should not underflow in draw", () => {
@@ -59,23 +59,23 @@ describe("honor system bag", () => {
       randomSeed: "1",
     });
     expect(() => bag.draw(6)).toThrow(RangeError);
-    expect(bag.draw(bag.size)).toEqual(_tiles(2, 3, 1, 5, 8));
+    expect(bag.draw(bag.size)).toEqual(_tiles(8, 2, 1, 5, 3));
   });
   it("should exchange 2", () => {
     const bag = createHonorSystemBag({
       tiles: _tiles(1, 2, 3, 5, 8),
       randomSeed: "1",
     });
-    expect(bag.exchange(_tiles(6, 7))).toEqual(_tiles(5, 8));
-    expect(bag.draw(bag.size)).toEqual(_tiles(1, 3, 6, 7, 2));
+    expect(bag.exchange(_tiles(6, 7))).toEqual(_tiles(5, 3));
+    expect(bag.draw(bag.size)).toEqual(_tiles(8, 7, 2, 1, 6));
   });
   it("should exchange all", () => {
     const bag = createHonorSystemBag({
       tiles: _tiles(1, 2, 3, 5, 8),
       randomSeed: "222222222",
     });
-    expect(bag.exchange(_tiles(0, 4, 6, 7, 9))).toEqual(_tiles(2, 1, 5, 8, 3));
-    expect(bag.draw(bag.size)).toEqual(_tiles(9, 4, 7, 6, 0));
+    expect(bag.exchange(_tiles(0, 4, 6, 7, 9))).toEqual(_tiles(1, 3, 8, 5, 2));
+    expect(bag.draw(bag.size)).toEqual(_tiles(4, 0, 6, 7, 9));
   });
   it("should not underflow in exchange", () => {
     const bag = createHonorSystemBag({
@@ -83,7 +83,7 @@ describe("honor system bag", () => {
       randomSeed: "1",
     });
     expect(() => bag.exchange(_tiles(1, 2, 3, 4, 5, 6))).toThrow(RangeError);
-    expect(bag.draw(bag.size)).toEqual(_tiles(2, 3, 1, 5, 8));
+    expect(bag.draw(bag.size)).toEqual(_tiles(8, 2, 1, 5, 3));
   });
   it("should support duplicates", () => {
     const bag = createHonorSystemBag({
@@ -91,7 +91,7 @@ describe("honor system bag", () => {
       randomSeed: "99",
     });
     expect(bag.exchange(_tiles(4, 4))).toEqual(_tiles(3, 3));
-    expect(bag.draw(bag.size)).toEqual(_tiles(4, 3, 4, 3));
+    expect(bag.draw(bag.size)).toEqual(_tiles(4, 3, 3, 4));
   });
   describe("json", () => {
     it("should roundtrip to and from JSON", () => {

--- a/game/honor_system_tiles_state_test.ts
+++ b/game/honor_system_tiles_state_test.ts
@@ -68,7 +68,7 @@ describe("honor system tiles state", () => {
       tiles,
       4,
     );
-    const daveWord = makeTestTiles({ A: 3, B: 1 }).map((tile, col) => ({
+    const daveWord = makeTestTiles({ A: 4 }).map((tile, col) => ({
       row: 1,
       col,
       tile,
@@ -82,7 +82,7 @@ describe("honor system tiles state", () => {
     expect(state.stateId).toEqual(2);
     expect(state.countTiles("John")).toEqual(4);
     expect(state.countTiles("Dave")).toEqual(3);
-    expect([...getAllTiles(state), ...daveWord]).toEqual(
+    expect([...getAllTiles(state), ...daveWord.map((p) => p.tile)]).toEqual(
       expect.arrayContaining(tiles),
     );
   });


### PR DESCRIPTION
…ting it as a decimal BigInt. This provides a more robust way to seed the random number generator from arbitrary strings.

- A djb2 hash function has been added in `game/hash.ts`.
- The `HonorSystemBag` constructor now uses this hash function to seed the `Mulberry32Prng`.
- Tests in `game/honor_system_bag_test.ts`, `game/game_state_test.ts`, and `game/honor_system_tiles_state_test.ts` have been updated to reflect the new shuffling behavior.